### PR TITLE
feat(kanban): add customisable kanban board view

### DIFF
--- a/Bar Tasker/AppDelegate.swift
+++ b/Bar Tasker/AppDelegate.swift
@@ -50,7 +50,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
   private var currentPopoverContentSize: NSSize {
     NSSize(
-      width: PopoverLayout.width,
+      width: PopoverLayout.preferredWidth(for: checkvistManager),
       height: PopoverLayout.preferredHeight(for: checkvistManager)
     )
   }

--- a/Bar Tasker/BarTaskerManager+Kanban.swift
+++ b/Bar Tasker/BarTaskerManager+Kanban.swift
@@ -1,0 +1,234 @@
+import Foundation
+
+extension BarTaskerManager {
+
+  // MARK: - Task filtering for kanban columns
+
+  /// Returns root-level tasks that belong to the given column.
+  /// Column membership uses first-match semantics: a task belongs to the first column
+  /// (in `allColumns` order) whose conditions it satisfies.
+  func tasksForKanbanColumn(_ column: KanbanColumn, allColumns: [KanbanColumn]) -> [CheckvistTask] {
+    let rootTasks = tasks.filter { $0.parentId == nil || $0.parentId == 0 }
+    let eligible = rootTasks.filter { task in
+      columnForTask(task, in: allColumns)?.id == column.id
+    }
+    return sortedForKanban(eligible, sortOrder: column.sortOrder)
+  }
+
+  /// Returns the first column (in order) that a task matches.
+  func columnForTask(_ task: CheckvistTask, in columns: [KanbanColumn]) -> KanbanColumn? {
+    // Build a set of all tag-based and due-based conditions from earlier columns
+    // so catch-all can exclude tasks already claimed.
+    for column in columns {
+      if taskMatchesKanbanColumn(task, column: column) {
+        return column
+      }
+    }
+    return nil
+  }
+
+  private func taskMatchesKanbanColumn(_ task: CheckvistTask, column: KanbanColumn) -> Bool {
+    for condition in column.conditions {
+      if taskMatchesCondition(task, condition: condition) {
+        return true
+      }
+    }
+    return false
+  }
+
+  func taskMatchesCondition(_ task: CheckvistTask, condition: KanbanColumnCondition) -> Bool {
+    switch condition {
+    case .tag(let name):
+      return hasTag(task, tag: name)
+    case .dueBucket(let raw):
+      guard let bucket = RootDueBucket(rawValue: raw) else { return false }
+      return rootDueBucket(for: task) == bucket
+    case .catchAll:
+      return true
+    }
+  }
+
+  private func hasTag(_ task: CheckvistTask, tag: String) -> Bool {
+    guard let tags = cache.tagsByTaskId[task.id] else { return false }
+    let normalized = tag.hasPrefix("#") || tag.hasPrefix("@")
+      ? tag.lowercased()
+      : "#\(tag.lowercased())"
+    return tags.contains(normalized)
+  }
+
+  private func sortedForKanban(_ tasks: [CheckvistTask], sortOrder: KanbanSortOrder) -> [CheckvistTask] {
+    switch sortOrder {
+    case .position:
+      return tasks.sorted { lhs, rhs in
+        switch (lhs.position, rhs.position) {
+        case (.some(let l), .some(let r)) where l != r: return l < r
+        default: return lhs.content.localizedCaseInsensitiveCompare(rhs.content) == .orderedAscending
+        }
+      }
+    case .dueAscending:
+      return tasks.sorted { lhs, rhs in
+        switch (lhs.dueDate, rhs.dueDate) {
+        case (.some(let l), .some(let r)): return l < r
+        case (.some, .none): return true
+        case (.none, .some): return false
+        default: return lhs.content.localizedCaseInsensitiveCompare(rhs.content) == .orderedAscending
+        }
+      }
+    case .dueDescending:
+      return tasks.sorted { lhs, rhs in
+        switch (lhs.dueDate, rhs.dueDate) {
+        case (.some(let l), .some(let r)): return l > r
+        case (.some, .none): return true
+        case (.none, .some): return false
+        default: return lhs.content.localizedCaseInsensitiveCompare(rhs.content) == .orderedAscending
+        }
+      }
+    case .priorityAscending:
+      return tasks.sorted { lhs, rhs in
+        let lp = priorityRank(for: lhs)
+        let rp = priorityRank(for: rhs)
+        if let lp, let rp, lp != rp { return lp < rp }
+        if lp != nil && rp == nil { return true }
+        if lp == nil && rp != nil { return false }
+        return lhs.content.localizedCaseInsensitiveCompare(rhs.content) == .orderedAscending
+      }
+    case .alphabetical:
+      return tasks.sorted {
+        $0.content.localizedCaseInsensitiveCompare($1.content) == .orderedAscending
+      }
+    }
+  }
+
+  // MARK: - Moving tasks between columns
+
+  /// Moves the currently selected task one column left or right and updates the task's
+  /// tag / due-date to match the target column's first writable condition.
+  @MainActor func moveCurrentTaskToKanbanColumn(direction: Int) async {
+    guard rootTaskView == .kanban else { return }
+    let columns = kanbanColumns
+    guard !columns.isEmpty, let task = currentTask else { return }
+
+    let currentColIndex = columns.firstIndex { col in
+      columnForTask(task, in: columns)?.id == col.id
+    } ?? kanbanFocusedColumnIndex
+
+    let targetIndex = currentColIndex + direction
+    guard columns.indices.contains(targetIndex) else { return }
+    let targetColumn = columns[targetIndex]
+
+    guard let (newContent, newDue) = applyColumnConditions(
+      to: task, targetColumn: targetColumn, allColumns: columns)
+    else {
+      errorMessage = "Can't move task into "\(targetColumn.name)" — no writable condition."
+      return
+    }
+
+    // Shift focused column to follow the task
+    kanbanFocusedColumnIndex = targetIndex
+    currentSiblingIndex = 0
+
+    if newContent != task.content || newDue != task.due {
+      await updateTask(
+        task: task,
+        content: newContent != task.content ? newContent : nil,
+        due: newDue != task.due ? newDue : nil
+      )
+    }
+  }
+
+  /// Computes the new content and due string needed to make `task` satisfy `targetColumn`.
+  /// Returns nil if no writable condition exists.
+  private func applyColumnConditions(
+    to task: CheckvistTask,
+    targetColumn: KanbanColumn,
+    allColumns: [KanbanColumn]
+  ) -> (content: String, due: String?)? {
+    // Find the first writable condition in the target column.
+    guard let writableCondition = targetColumn.conditions.first(where: { $0.isWritable }) else {
+      return nil
+    }
+
+    var content = task.content
+    var due: String? = task.due
+
+    // Strip tags that belong to other tag-based columns so there's no ambiguity.
+    let otherColumnTags: [String] = allColumns
+      .filter { $0.id != targetColumn.id }
+      .flatMap { col in
+        col.conditions.compactMap {
+          if case .tag(let t) = $0 { return t } else { return nil }
+        }
+      }
+    for tag in otherColumnTags {
+      content = content
+        .replacingOccurrences(of: " #\(tag)", with: "")
+        .replacingOccurrences(of: "#\(tag)", with: "")
+        .trimmingCharacters(in: .whitespaces)
+    }
+
+    switch writableCondition {
+    case .tag(let name):
+      if !content.lowercased().contains("#\(name.lowercased())") {
+        content = "\(content) #\(name)"
+      }
+
+    case .dueBucket(let raw):
+      guard let bucket = RootDueBucket(rawValue: raw) else { return nil }
+      let calendar = Calendar.current
+      let today = calendar.startOfDay(for: Date())
+      let formatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+      }()
+      switch bucket {
+      case .today:
+        due = formatter.string(from: today)
+      case .tomorrow:
+        due = formatter.string(from: calendar.date(byAdding: .day, value: 1, to: today)!)
+      case .noDueDate:
+        due = ""
+      default:
+        return nil  // non-writable bucket
+      }
+
+    case .catchAll:
+      // Clear all column-associated tags and due date so task falls to catch-all.
+      due = nil  // leave due unchanged; catch-all just means "nothing else matches"
+    }
+
+    return (content, due)
+  }
+
+  // MARK: - Column focus navigation (no task move)
+
+  @MainActor func focusKanbanColumn(direction: Int) {
+    guard rootTaskView == .kanban else { return }
+    let next = kanbanFocusedColumnIndex + direction
+    guard kanbanColumns.indices.contains(next) else { return }
+    kanbanFocusedColumnIndex = next
+    currentSiblingIndex = 0
+  }
+
+  // MARK: - Kanban column persistence
+
+  func loadKanbanColumns() -> [KanbanColumn] {
+    guard
+      let data = preferencesStore.string(.kanbanColumns).data(using: .utf8),
+      !data.isEmpty,
+      let decoded = try? JSONDecoder().decode([KanbanColumn].self, from: data),
+      !decoded.isEmpty
+    else {
+      return KanbanColumn.defaults
+    }
+    return decoded
+  }
+
+  func saveKanbanColumns(_ columns: [KanbanColumn]) {
+    guard let data = try? JSONEncoder().encode(columns),
+      let json = String(data: data, encoding: .utf8)
+    else { return }
+    preferencesStore.set(json, for: .kanbanColumns)
+  }
+}

--- a/Bar Tasker/BarTaskerManager+StateAndLifecycle.swift
+++ b/Bar Tasker/BarTaskerManager+StateAndLifecycle.swift
@@ -27,7 +27,9 @@ extension BarTaskerManager {
       $selectedRootTag.map { _ in () }.eraseToAnyPublisher(),
       $quickEntryMode.map { _ in () }.eraseToAnyPublisher(),
       $priorityTaskIds.map { _ in () }.eraseToAnyPublisher(),
-      $timerByTaskId.map { _ in () }.eraseToAnyPublisher()
+      $timerByTaskId.map { _ in () }.eraseToAnyPublisher(),
+      $kanbanColumns.map { _ in () }.eraseToAnyPublisher(),
+      $kanbanFocusedColumnIndex.map { _ in () }.eraseToAnyPublisher()
     )
     .sink { [weak self] _ in
       self?.invalidateCaches()
@@ -126,6 +128,12 @@ extension BarTaskerManager {
       self?.preferencesStore.set($0.rawValue, for: .rootTaskView)
     }
     .store(in: &cancellables)
+    $kanbanColumns
+      .dropFirst()
+      .sink { [weak self] columns in
+        self?.saveKanbanColumns(columns)
+      }
+      .store(in: &cancellables)
     $selectedRootDueBucketRawValue.sink { [weak self] in
       self?.preferencesStore.set($0, for: .selectedRootDueBucketRawValue)
     }

--- a/Bar Tasker/BarTaskerManager+TaskScoping.swift
+++ b/Bar Tasker/BarTaskerManager+TaskScoping.swift
@@ -140,7 +140,8 @@ extension BarTaskerManager {
 
   var shouldShowRootScopeSection: Bool { !needsInitialSetup && !isSearchFilterActive }
   var rootScopeShowsFilterControls: Bool {
-    shouldShowRootScopeSection && isRootLevel && (rootTaskView == .due || rootTaskView == .tags)
+    shouldShowRootScopeSection && isRootLevel
+      && (rootTaskView == .due || rootTaskView == .tags)
   }
 
   var selectedRootDueBucket: RootDueBucket? {

--- a/Bar Tasker/BarTaskerManager+Types.swift
+++ b/Bar Tasker/BarTaskerManager+Types.swift
@@ -28,6 +28,7 @@ extension BarTaskerManager {
     case due
     case tags
     case priority
+    case kanban
 
     var title: String {
       switch self {
@@ -35,6 +36,7 @@ extension BarTaskerManager {
       case .due: return "Due"
       case .tags: return "Tags"
       case .priority: return "Priority"
+      case .kanban: return "Kanban"
       }
     }
   }
@@ -171,6 +173,11 @@ extension BarTaskerManager {
     case clearPriority
     case pushPriorityBack
     case setPriorityRank
+    case kanbanMoveLeft
+    case kanbanMoveRight
+    case kanbanFocusLeft
+    case kanbanFocusRight
+    case rootTabKanban
 
     var id: String { rawValue }
 
@@ -226,6 +233,11 @@ extension BarTaskerManager {
       case .clearPriority: return "Clear priority"
       case .pushPriorityBack: return "Send priority to back"
       case .setPriorityRank: return "Set priority rank"
+      case .kanbanMoveLeft: return "Kanban: move task to previous column"
+      case .kanbanMoveRight: return "Kanban: move task to next column"
+      case .kanbanFocusLeft: return "Kanban: focus previous column"
+      case .kanbanFocusRight: return "Kanban: focus next column"
+      case .rootTabKanban: return "Jump to root tab: Kanban"
       }
     }
 
@@ -234,11 +246,12 @@ extension BarTaskerManager {
       case .nextTask, .previousTask, .enterChildren, .exitToParent, .rootCycleTabPrevious,
         .rootCycleTabNext, .rootCycleFilterPrevious, .rootCycleFilterNext, .rootTabAll, .rootTabDue,
         .rootTabTags, .rootTabPriority, .rootFilter1, .rootFilter2, .rootFilter3, .rootFilter4,
-        .rootFilter5, .rootFilter6, .rootFilter7:
+        .rootFilter5, .rootFilter6, .rootFilter7, .rootTabKanban,
+        .kanbanFocusLeft, .kanbanFocusRight:
         return "Navigation"
       case .markDone, .invalidateTask, .addSibling, .addChild, .unindentTask, .editTaskAtEnd,
         .editTaskAtStart, .deleteTask, .moveTaskUp, .moveTaskDown, .undo, .clearPriority,
-        .pushPriorityBack, .setPriorityRank:
+        .pushPriorityBack, .setPriorityRank, .kanbanMoveLeft, .kanbanMoveRight:
         return "Task Actions"
       case .openCommandPalette, .closeOrCancel, .focusSearch, .sequenceDue, .sequenceDueToday,
         .sequenceTag, .sequenceUntag, .sequenceToggleContext, .quickListSwitch, .quickAdd:
@@ -301,6 +314,11 @@ extension BarTaskerManager {
       case .clearPriority: return "-"
       case .pushPriorityBack: return "="
       case .setPriorityRank: return "1,2,3,4,5,6,7,8,9"
+      case .kanbanMoveLeft: return "cmd+left"
+      case .kanbanMoveRight: return "cmd+right"
+      case .kanbanFocusLeft: return "left,h"
+      case .kanbanFocusRight: return "right,l"
+      case .rootTabKanban: return "t"
       }
     }
   }

--- a/Bar Tasker/BarTaskerManager.swift
+++ b/Bar Tasker/BarTaskerManager.swift
@@ -105,6 +105,10 @@ class BarTaskerManager: ObservableObject {
   @Published var quickAddSpecificParentTaskId: String
   @Published var customizableShortcutsByAction: [String: String]
 
+  // MARK: - Kanban
+  @Published var kanbanColumns: [KanbanColumn]
+  @Published var kanbanFocusedColumnIndex: Int = 0
+
   /// Max width of the menu bar text
   @Published var maxTitleWidth: Double
   @Published var onboardingCompleted: Bool
@@ -274,6 +278,16 @@ class BarTaskerManager: ObservableObject {
     let persistedShortcutOverrides = preferencesStore.stringDictionary(
       .customizableShortcutsByAction)
     self.customizableShortcutsByAction = persistedShortcutOverrides
+    let storedKanbanJson = preferencesStore.string(.kanbanColumns)
+    if !storedKanbanJson.isEmpty,
+      let data = storedKanbanJson.data(using: .utf8),
+      let decoded = try? JSONDecoder().decode([KanbanColumn].self, from: data),
+      !decoded.isEmpty
+    {
+      self.kanbanColumns = decoded
+    } else {
+      self.kanbanColumns = KanbanColumn.defaults
+    }
     self.maxTitleWidth = preferencesStore.double(.maxTitleWidth, default: 150.0)
     if let storedOnboarding = storedOnboardingCompletedFlag {
       self.onboardingCompleted = storedOnboarding

--- a/Bar Tasker/BarTaskerPreferencesStore.swift
+++ b/Bar Tasker/BarTaskerPreferencesStore.swift
@@ -35,6 +35,7 @@ final class BarTaskerPreferencesStore {
     case themeColorTokenHexOverrides
     case customizableShortcutsByAction
     case dismissedOnboardingDialogs
+    case kanbanColumns
   }
 
   private let defaults: UserDefaults

--- a/Bar Tasker/KanbanBoardView.swift
+++ b/Bar Tasker/KanbanBoardView.swift
@@ -1,0 +1,277 @@
+import SwiftUI
+
+// MARK: - KanbanBoardView
+
+struct KanbanBoardView: View {
+  @EnvironmentObject var manager: BarTaskerManager
+
+  private func themeColor(_ token: BarTaskerThemeColorToken) -> Color {
+    manager.themeColor(for: token)
+  }
+
+  var body: some View {
+    let columns = manager.kanbanColumns
+    let childCounts = manager.childCountByTaskId()
+    HStack(alignment: .top, spacing: 0) {
+      ForEach(Array(columns.enumerated()), id: \.element.id) { colIndex, column in
+        let tasks = manager.tasksForKanbanColumn(column, allColumns: columns)
+        let isFocused = colIndex == manager.kanbanFocusedColumnIndex
+        KanbanColumnView(
+          column: column,
+          tasks: tasks,
+          columnIndex: colIndex,
+          isFocused: isFocused,
+          childCounts: childCounts
+        )
+        if colIndex < columns.count - 1 {
+          Divider()
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+  }
+}
+
+// MARK: - KanbanColumnView
+
+private struct KanbanColumnView: View {
+  @EnvironmentObject var manager: BarTaskerManager
+  let column: KanbanColumn
+  let tasks: [CheckvistTask]
+  let columnIndex: Int
+  let isFocused: Bool
+  let childCounts: [Int: Int]
+
+  private func themeColor(_ token: BarTaskerThemeColorToken) -> Color {
+    manager.themeColor(for: token)
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      columnHeader
+      Divider()
+      taskListArea
+    }
+    .frame(width: PopoverLayout.kanbanColumnWidth, maxHeight: .infinity, alignment: .topLeading)
+    .overlay {
+      if isFocused {
+        Rectangle()
+          .stroke(themeColor(.focusRing), lineWidth: 1)
+          .allowsHitTesting(false)
+      }
+    }
+  }
+
+  private var columnHeader: some View {
+    HStack(spacing: 6) {
+      Text(column.name)
+        .font(.system(size: 12, weight: .semibold))
+        .foregroundColor(isFocused ? themeColor(.selectionForeground) : themeColor(.textPrimary))
+      Spacer()
+      Text("\(tasks.count)")
+        .font(.system(size: 11, weight: .medium))
+        .foregroundColor(themeColor(.textSecondary))
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(themeColor(.panelSurface))
+        .clipShape(Capsule())
+    }
+    .padding(.horizontal, 10)
+    .padding(.vertical, 7)
+    .background(
+      isFocused
+        ? themeColor(.selectionBackground).opacity(0.18)
+        : themeColor(.panelBackground)
+    )
+  }
+
+  private var taskListArea: some View {
+    Group {
+      if tasks.isEmpty {
+        VStack {
+          Spacer()
+          Text("No tasks")
+            .font(.caption)
+            .foregroundColor(themeColor(.textSecondary))
+          Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+      } else {
+        ScrollViewReader { proxy in
+          ScrollView {
+            VStack(spacing: 0) {
+              ForEach(Array(tasks.enumerated()), id: \.element.id) { taskIndex, task in
+                let isSelected =
+                  isFocused && taskIndex == manager.currentSiblingIndex
+                KanbanTaskCard(
+                  task: task,
+                  isSelected: isSelected,
+                  childCount: childCounts[task.id, default: 0]
+                )
+                .id(task.id)
+                .onTapGesture {
+                  manager.kanbanFocusedColumnIndex = columnIndex
+                  manager.rootScopeFocusLevel = 0
+                  manager.currentSiblingIndex = taskIndex
+                }
+              }
+            }
+          }
+          .onChange(of: manager.currentSiblingIndex) { _, _ in
+            guard isFocused, let task = manager.currentTask else { return }
+            if tasks.contains(where: { $0.id == task.id }) {
+              proxy.scrollTo(task.id, anchor: .center)
+            }
+          }
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+  }
+}
+
+// MARK: - KanbanTaskCard
+
+private struct KanbanTaskCard: View {
+  @EnvironmentObject var manager: BarTaskerManager
+  let task: CheckvistTask
+  let isSelected: Bool
+  let childCount: Int
+
+  private func themeColor(_ token: BarTaskerThemeColorToken) -> Color {
+    manager.themeColor(for: token)
+  }
+
+  private var isCompleting: Bool { manager.completingTaskId == task.id }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack(alignment: .top, spacing: 8) {
+        Image(
+          systemName: isCompleting
+            ? "checkmark.circle.fill"
+            : isSelected ? "largecircle.fill.circle" : "circle"
+        )
+        .foregroundColor(
+          isCompleting
+            ? themeColor(.success)
+            : isSelected ? themeColor(.selectionForeground) : themeColor(.textSecondary)
+        )
+        .font(.system(size: 13))
+        .padding(.top, 1)
+        .scaleEffect(isCompleting ? 1.3 : 1.0)
+        .animation(.spring(response: 0.28, dampingFraction: 0.45), value: isCompleting)
+        .symbolEffect(.bounce, value: isCompleting)
+        .onTapGesture {
+          Task { await manager.markCurrentTaskDone() }
+        }
+
+        VStack(alignment: .leading, spacing: 3) {
+          Text(task.content.strippingTags)
+            .font(.system(size: 12))
+            .foregroundColor(isSelected ? themeColor(.selectionForeground) : themeColor(.textPrimary))
+            .lineLimit(3)
+            .fixedSize(horizontal: false, vertical: true)
+
+          metadataRow
+        }
+      }
+      .padding(.horizontal, 10)
+      .padding(.vertical, 8)
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(
+      isSelected
+        ? themeColor(.selectionBackground)
+        : themeColor(.panelBackground)
+    )
+    .overlay(alignment: .leading) {
+      if isSelected {
+        Rectangle()
+          .fill(themeColor(.selectionForeground))
+          .frame(width: 3)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var metadataRow: some View {
+    let hasDue = !(task.due ?? "").isEmpty
+    let tags = extractTags(from: task.content)
+    let hasChildren = childCount > 0
+
+    if hasDue || !tags.isEmpty || hasChildren {
+      HStack(spacing: 5) {
+        if hasDue, let due = task.due {
+          let bucket = manager.rootDueBucket(for: task)
+          let isOverdue = bucket == .overdue
+          let isToday = bucket == .today
+          Text(due == "asap" ? "ASAP" : shortDateString(due))
+            .font(.system(size: 10, weight: .medium))
+            .foregroundColor(
+              isOverdue ? themeColor(.danger)
+              : isToday ? themeColor(.warning)
+              : themeColor(.textSecondary)
+            )
+        }
+
+        ForEach(tags.prefix(3), id: \.self) { tag in
+          Text(tag)
+            .font(.system(size: 10))
+            .foregroundColor(themeColor(.accent))
+        }
+
+        if hasChildren {
+          HStack(spacing: 2) {
+            Image(systemName: "chevron.right")
+              .font(.system(size: 9))
+            Text("\(childCount)")
+              .font(.system(size: 10))
+          }
+          .foregroundColor(themeColor(.textSecondary))
+        }
+      }
+    }
+  }
+
+  private func extractTags(from content: String) -> [String] {
+    let pattern = try? NSRegularExpression(pattern: "[#@][\\w-]+")
+    let range = NSRange(content.startIndex..., in: content)
+    let matches = pattern?.matches(in: content, range: range) ?? []
+    return matches.compactMap { match in
+      guard let r = Range(match.range, in: content) else { return nil }
+      return String(content[r])
+    }
+  }
+
+  private func shortDateString(_ due: String) -> String {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    // Try date-only format first
+    formatter.dateFormat = "yyyy-MM-dd"
+    if let date = formatter.date(from: due) {
+      let out = DateFormatter()
+      out.dateFormat = "MMM d"
+      return out.string(from: date)
+    }
+    // Try datetime format
+    formatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
+    if let date = formatter.date(from: due) {
+      let out = DateFormatter()
+      out.dateFormat = "MMM d"
+      return out.string(from: date)
+    }
+    return due
+  }
+}
+
+// MARK: - String helper
+
+private extension String {
+  /// Returns the content string with inline tags stripped for cleaner display.
+  var strippingTags: String {
+    let pattern = try? NSRegularExpression(pattern: "\\s*[#@][\\w-]+")
+    let range = NSRange(startIndex..., in: self)
+    return pattern?.stringByReplacingMatches(in: self, range: range, withTemplate: "") ?? self
+  }
+}

--- a/Bar Tasker/KanbanColumn.swift
+++ b/Bar Tasker/KanbanColumn.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+// MARK: - KanbanColumnCondition
+
+enum KanbanColumnCondition: Codable, Hashable {
+  /// Task has this tag in its content (without the # prefix).
+  case tag(String)
+  /// Task falls in this due bucket (stored as RootDueBucket.rawValue).
+  case dueBucket(Int)
+  /// Catch-all: matches any task not already claimed by an earlier column.
+  case catchAll
+
+  var displayTitle: String {
+    switch self {
+    case .tag(let name): return "#\(name)"
+    case .dueBucket(let raw):
+      return BarTaskerManager.RootDueBucket(rawValue: raw)?.title ?? "Due bucket \(raw)"
+    case .catchAll: return "Everything else"
+    }
+  }
+
+  /// Whether moving a task into this condition is actionable (can set a due date or tag).
+  var isWritable: Bool {
+    switch self {
+    case .tag: return true
+    case .dueBucket(let raw):
+      guard let bucket = BarTaskerManager.RootDueBucket(rawValue: raw) else { return false }
+      switch bucket {
+      case .today, .tomorrow, .noDueDate: return true
+      default: return false
+      }
+    case .catchAll: return true
+    }
+  }
+}
+
+// MARK: - KanbanSortOrder
+
+enum KanbanSortOrder: String, Codable, CaseIterable, Identifiable {
+  case position
+  case dueAscending
+  case dueDescending
+  case priorityAscending
+  case alphabetical
+
+  var id: String { rawValue }
+
+  var title: String {
+    switch self {
+    case .position: return "Default order"
+    case .dueAscending: return "Due date (earliest first)"
+    case .dueDescending: return "Due date (latest first)"
+    case .priorityAscending: return "Priority (highest first)"
+    case .alphabetical: return "Alphabetical"
+    }
+  }
+}
+
+// MARK: - KanbanColumn
+
+struct KanbanColumn: Identifiable, Codable {
+  var id: UUID
+  var name: String
+  /// A task matches this column if it satisfies ANY of these conditions (OR logic).
+  /// Columns are evaluated in order; a task belongs to the first column it matches.
+  var conditions: [KanbanColumnCondition]
+  var sortOrder: KanbanSortOrder
+
+  init(
+    id: UUID = UUID(),
+    name: String,
+    conditions: [KanbanColumnCondition],
+    sortOrder: KanbanSortOrder = .position
+  ) {
+    self.id = id
+    self.name = name
+    self.conditions = conditions
+    self.sortOrder = sortOrder
+  }
+
+  static var defaults: [KanbanColumn] {
+    [
+      KanbanColumn(
+        name: "Inbox",
+        conditions: [.catchAll],
+        sortOrder: .position
+      ),
+      KanbanColumn(
+        name: "Today",
+        conditions: [
+          .dueBucket(BarTaskerManager.RootDueBucket.overdue.rawValue),
+          .dueBucket(BarTaskerManager.RootDueBucket.today.rawValue),
+        ],
+        sortOrder: .dueAscending
+      ),
+      KanbanColumn(
+        name: "Upcoming",
+        conditions: [
+          .dueBucket(BarTaskerManager.RootDueBucket.tomorrow.rawValue),
+          .dueBucket(BarTaskerManager.RootDueBucket.nextSevenDays.rawValue),
+        ],
+        sortOrder: .dueAscending
+      ),
+    ]
+  }
+}

--- a/Bar Tasker/KanbanSettingsView.swift
+++ b/Bar Tasker/KanbanSettingsView.swift
@@ -1,0 +1,299 @@
+import SwiftUI
+
+// MARK: - KanbanSettingsView
+
+struct KanbanSettingsView: View {
+  @EnvironmentObject var manager: BarTaskerManager
+
+  @State private var editingColumn: KanbanColumn? = nil
+  @State private var showingAddColumn = false
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      headerRow
+      Divider()
+      columnList
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    .sheet(item: $editingColumn) { col in
+      KanbanColumnEditorView(column: col) { updated in
+        if let idx = manager.kanbanColumns.firstIndex(where: { $0.id == updated.id }) {
+          manager.kanbanColumns[idx] = updated
+        }
+        editingColumn = nil
+      } onCancel: {
+        editingColumn = nil
+      }
+    }
+    .sheet(isPresented: $showingAddColumn) {
+      let fresh = KanbanColumn(name: "New Column", conditions: [.catchAll])
+      KanbanColumnEditorView(column: fresh) { created in
+        manager.kanbanColumns.append(created)
+        showingAddColumn = false
+      } onCancel: {
+        showingAddColumn = false
+      }
+    }
+  }
+
+  private var headerRow: some View {
+    HStack {
+      VStack(alignment: .leading, spacing: 2) {
+        Text("Kanban Columns")
+          .font(.system(size: 13, weight: .semibold))
+        Text("Columns are evaluated left-to-right; a task appears in the first column it matches.")
+          .font(.caption)
+          .foregroundColor(.secondary)
+      }
+      Spacer()
+      Button {
+        showingAddColumn = true
+      } label: {
+        Label("Add Column", systemImage: "plus")
+          .font(.system(size: 12))
+      }
+      .buttonStyle(.bordered)
+      .controlSize(.small)
+    }
+    .padding(16)
+  }
+
+  private var columnList: some View {
+    List {
+      ForEach(manager.kanbanColumns) { col in
+        KanbanColumnRow(column: col) {
+          editingColumn = col
+        } onDelete: {
+          manager.kanbanColumns.removeAll { $0.id == col.id }
+        }
+      }
+      .onMove { from, to in
+        manager.kanbanColumns.move(fromOffsets: from, toOffset: to)
+      }
+    }
+    .listStyle(.inset)
+  }
+}
+
+// MARK: - KanbanColumnRow
+
+private struct KanbanColumnRow: View {
+  let column: KanbanColumn
+  let onEdit: () -> Void
+  let onDelete: () -> Void
+
+  var body: some View {
+    HStack(spacing: 10) {
+      VStack(alignment: .leading, spacing: 3) {
+        Text(column.name)
+          .font(.system(size: 13, weight: .medium))
+        conditionsSummary
+      }
+      Spacer()
+      Text(column.sortOrder.title)
+        .font(.caption)
+        .foregroundColor(.secondary)
+      Button("Edit", action: onEdit)
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+      Button(role: .destructive, action: onDelete) {
+        Image(systemName: "trash")
+      }
+      .buttonStyle(.plain)
+      .foregroundColor(.red)
+    }
+    .padding(.vertical, 4)
+  }
+
+  private var conditionsSummary: some View {
+    let titles = column.conditions.map(\.displayTitle)
+    return Text(titles.joined(separator: " or "))
+      .font(.caption)
+      .foregroundColor(.secondary)
+      .lineLimit(1)
+  }
+}
+
+// MARK: - KanbanColumnEditorView
+
+struct KanbanColumnEditorView: View {
+  @State var column: KanbanColumn
+  let onSave: (KanbanColumn) -> Void
+  let onCancel: () -> Void
+
+  @State private var pendingCondition: PendingCondition = .tag
+  @State private var pendingTagName: String = ""
+  @State private var pendingDueBucket: BarTaskerManager.RootDueBucket = .today
+
+  private enum PendingCondition: String, CaseIterable, Identifiable {
+    case tag, due, catchAll
+    var id: String { rawValue }
+    var title: String {
+      switch self {
+      case .tag: return "Tag"
+      case .due: return "Due bucket"
+      case .catchAll: return "Everything else (catch-all)"
+      }
+    }
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      Text(column.name.isEmpty ? "New Column" : column.name)
+        .font(.headline)
+
+      Group {
+        LabeledContent("Name") {
+          TextField("Column name", text: $column.name)
+            .textFieldStyle(.roundedBorder)
+            .frame(maxWidth: 240)
+        }
+
+        LabeledContent("Sort order") {
+          Picker("", selection: $column.sortOrder) {
+            ForEach(KanbanSortOrder.allCases) { order in
+              Text(order.title).tag(order)
+            }
+          }
+          .pickerStyle(.menu)
+          .frame(maxWidth: 240)
+        }
+      }
+
+      Divider()
+
+      Text("Conditions")
+        .font(.system(size: 12, weight: .semibold))
+      Text("A task matches this column if it satisfies any condition below.")
+        .font(.caption)
+        .foregroundColor(.secondary)
+
+      conditionList
+
+      Divider()
+
+      addConditionSection
+
+      Spacer()
+
+      HStack {
+        Spacer()
+        Button("Cancel", action: onCancel)
+          .keyboardShortcut(.cancelAction)
+        Button("Save") { onSave(column) }
+          .keyboardShortcut(.defaultAction)
+          .disabled(column.name.trimmingCharacters(in: .whitespaces).isEmpty)
+      }
+    }
+    .padding(20)
+    .frame(width: 480, height: 460)
+  }
+
+  private var conditionList: some View {
+    List {
+      if column.conditions.isEmpty {
+        Text("No conditions — add one below.")
+          .foregroundColor(.secondary)
+          .font(.caption)
+      } else {
+        ForEach(Array(column.conditions.enumerated()), id: \.offset) { idx, cond in
+          HStack {
+            Image(systemName: conditionIcon(cond))
+              .foregroundColor(.secondary)
+              .frame(width: 16)
+            Text(cond.displayTitle)
+              .font(.system(size: 12))
+            Spacer()
+            Button {
+              column.conditions.remove(at: idx)
+            } label: {
+              Image(systemName: "minus.circle.fill")
+                .foregroundColor(.red)
+            }
+            .buttonStyle(.plain)
+          }
+        }
+        .onMove { from, to in
+          column.conditions.move(fromOffsets: from, toOffset: to)
+        }
+      }
+    }
+    .listStyle(.inset)
+    .frame(height: 120)
+  }
+
+  private var addConditionSection: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("Add condition")
+        .font(.system(size: 12, weight: .semibold))
+
+      HStack(spacing: 8) {
+        Picker("", selection: $pendingCondition) {
+          ForEach(PendingCondition.allCases) { c in
+            Text(c.title).tag(c)
+          }
+        }
+        .pickerStyle(.menu)
+        .frame(width: 180)
+
+        switch pendingCondition {
+        case .tag:
+          TextField("#tagname", text: $pendingTagName)
+            .textFieldStyle(.roundedBorder)
+            .frame(width: 120)
+        case .due:
+          Picker("", selection: $pendingDueBucket) {
+            ForEach(BarTaskerManager.RootDueBucket.allCases, id: \.rawValue) { bucket in
+              Text(bucket.title).tag(bucket)
+            }
+          }
+          .pickerStyle(.menu)
+          .frame(width: 160)
+        case .catchAll:
+          EmptyView()
+        }
+
+        Button("Add") {
+          addPendingCondition()
+        }
+        .buttonStyle(.bordered)
+        .disabled(!canAddPendingCondition)
+      }
+    }
+  }
+
+  private var canAddPendingCondition: Bool {
+    switch pendingCondition {
+    case .tag: return !pendingTagName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    case .due, .catchAll: return true
+    }
+  }
+
+  private func addPendingCondition() {
+    let condition: KanbanColumnCondition
+    switch pendingCondition {
+    case .tag:
+      let name = pendingTagName
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .replacingOccurrences(of: "#", with: "")
+      guard !name.isEmpty else { return }
+      condition = .tag(name)
+      pendingTagName = ""
+    case .due:
+      condition = .dueBucket(pendingDueBucket.rawValue)
+    case .catchAll:
+      condition = .catchAll
+    }
+    // Avoid duplicates
+    guard !column.conditions.contains(condition) else { return }
+    column.conditions.append(condition)
+  }
+
+  private func conditionIcon(_ cond: KanbanColumnCondition) -> String {
+    switch cond {
+    case .tag: return "tag"
+    case .dueBucket: return "calendar"
+    case .catchAll: return "tray"
+    }
+  }
+}

--- a/Bar Tasker/KeyboardShortcutRouter.swift
+++ b/Bar Tasker/KeyboardShortcutRouter.swift
@@ -149,6 +149,22 @@ struct KeyboardShortcutRouter {
       }
     }
 
+    // Cmd+←/→ - move task to adjacent kanban column (kanban mode only).
+    if manager.rootTaskView == .kanban && !isFocused {
+      if matches(.kanbanMoveLeft) {
+        if !isRepeat {
+          Task { await manager.moveCurrentTaskToKanbanColumn(direction: -1) }
+        }
+        return true
+      }
+      if matches(.kanbanMoveRight) {
+        if !isRepeat {
+          Task { await manager.moveCurrentTaskToKanbanColumn(direction: 1) }
+        }
+        return true
+      }
+    }
+
     // Cmd+↑/↓ - reorder (ignore key repeat to prevent rapid-fire API calls).
     if matches(.moveTaskDown) {
       if !isRepeat {
@@ -232,6 +248,20 @@ struct KeyboardShortcutRouter {
       }
       if event.keyCode == 36 || event.keyCode == 53 {
         manager.rootScopeFocusLevel = 0
+        return true
+      }
+    }
+
+    // In kanban mode, ←/→ (h/l) navigate between columns without moving the task.
+    if manager.rootTaskView == .kanban && !isFocused && !rootScopeFocused {
+      if matches(.kanbanFocusLeft) {
+        manager.focusKanbanColumn(direction: -1)
+        updateTitle()
+        return true
+      }
+      if matches(.kanbanFocusRight) {
+        manager.focusKanbanColumn(direction: 1)
+        updateTitle()
         return true
       }
     }
@@ -387,6 +417,11 @@ struct KeyboardShortcutRouter {
       }
       if matches(.rootTabPriority) {
         manager.setRootTaskView(.priority)
+        updateTitle()
+        return true
+      }
+      if matches(.rootTabKanban) {
+        manager.setRootTaskView(.kanban)
         updateTitle()
         return true
       }

--- a/Bar Tasker/PopoverView.swift
+++ b/Bar Tasker/PopoverView.swift
@@ -4,8 +4,16 @@ import SwiftUI
 // swiftlint:disable file_length
 enum PopoverLayout {
   static let width: CGFloat = 360
+  static let kanbanColumnWidth: CGFloat = 240
   static let minHeight: CGFloat = 220
   static let maxHeight: CGFloat = 520
+
+  @MainActor
+  static func preferredWidth(for manager: BarTaskerManager) -> CGFloat {
+    guard manager.rootTaskView == .kanban else { return width }
+    let count = max(1, manager.kanbanColumns.count)
+    return CGFloat(count) * kanbanColumnWidth
+  }
   static let cornerRadius: CGFloat = 10
   static let topStripHeight: CGFloat = 6
   static let rootScopeHorizontalInset: CGFloat = 8
@@ -346,6 +354,7 @@ struct PopoverView: View {
 
   var body: some View {
     let panelHeight = PopoverLayout.preferredHeight(for: manager)
+    let panelWidth = PopoverLayout.preferredWidth(for: manager)
 
     VStack(alignment: .leading, spacing: 0) {
       topBevelArea
@@ -366,9 +375,14 @@ struct PopoverView: View {
         Divider()
       }
 
-      // Task list — keyboard navigable
-      taskList
-        .frame(maxHeight: .infinity, alignment: .top)
+      // Task list / Kanban board — keyboard navigable
+      if manager.rootTaskView == .kanban {
+        KanbanBoardView()
+          .frame(maxHeight: .infinity, alignment: .top)
+      } else {
+        taskList
+          .frame(maxHeight: .infinity, alignment: .top)
+      }
       Divider()
 
       // Delete confirmation banner
@@ -388,7 +402,7 @@ struct PopoverView: View {
       }
 
     }
-    .frame(width: PopoverLayout.width, height: panelHeight, alignment: .top)
+    .frame(width: panelWidth, height: panelHeight, alignment: .top)
     .background(themeColor(.panelBackground))
     .tint(manager.themeAccentColor)
     .clipShape(RoundedRectangle(cornerRadius: PopoverLayout.cornerRadius))

--- a/Bar Tasker/SettingsNavState.swift
+++ b/Bar Tasker/SettingsNavState.swift
@@ -7,6 +7,7 @@ final class SettingsNavState: NSObject, ObservableObject {
     case keybindings
     case theme
     case plugins
+    case kanban
     #if DEBUG
       case debug
     #endif
@@ -17,6 +18,7 @@ final class SettingsNavState: NSObject, ObservableObject {
       case .keybindings: "Keybindings"
       case .theme: "Theme"
       case .plugins: "Plugins"
+      case .kanban: "Kanban"
       #if DEBUG
         case .debug: "Debug"
       #endif
@@ -29,6 +31,7 @@ final class SettingsNavState: NSObject, ObservableObject {
       case .keybindings: "keyboard"
       case .theme: "paintpalette"
       case .plugins: "puzzlepiece.extension"
+      case .kanban: "rectangle.split.3x1"
       #if DEBUG
         case .debug: "ladybug"
       #endif
@@ -36,7 +39,7 @@ final class SettingsNavState: NSObject, ObservableObject {
     }
 
     static var allPanes: [Pane] {
-      var panes: [Pane] = [.preferences, .keybindings, .theme, .plugins]
+      var panes: [Pane] = [.preferences, .keybindings, .theme, .plugins, .kanban]
       #if DEBUG
         panes.append(.debug)
       #endif

--- a/Bar Tasker/SettingsView.swift
+++ b/Bar Tasker/SettingsView.swift
@@ -218,6 +218,8 @@ struct SettingsView: View {
       themePane
     case .plugins:
       pluginsPane
+    case .kanban:
+      KanbanSettingsView()
     #if DEBUG
       case .debug:
         debugPane


### PR DESCRIPTION
- New KanbanColumn model with tag/due-bucket/catch-all conditions (OR logic,
  first-match across columns) and per-column sort order (position, due asc/desc,
  priority, alphabetical)
- KanbanBoardView: horizontal column layout; popover expands width dynamically
  (240 px per column) when the Kanban tab is active
- KanbanBoardView highlights the focused column and updates on tap/keyboard
- KanbanSettingsView: full add/edit/delete/reorder UI for columns and conditions,
  accessible from a new Kanban pane in Preferences
- BarTaskerManager+Kanban: tasksForKanbanColumn (filtering + sorting),
  moveCurrentTaskToKanbanColumn (cmd+←/→ updates tag or due date to match target
  column), focusKanbanColumn (h/l switches focus without moving the task)
- Keyboard: cmd+←/→ move task to adjacent column; h/l focus adjacent column;
  t jumps to the Kanban tab; existing cmd+↑/↓ still reorders within a column
- Column config persisted to UserDefaults as JSON; defaults to Inbox/Today/Upcoming

https://claude.ai/code/session_01BDDjN2V5agybNKG6Zz6fYu